### PR TITLE
Fix: enforce non-empty asset list when publishing

### DIFF
--- a/tools/devops/create-release.py
+++ b/tools/devops/create-release.py
@@ -22,7 +22,10 @@ from urllib.parse import urlparse
 @click.option('--auto-release-notes', is_flag=True, default=False)
 def main(version: str, previous: str, max_message_lines: int, publish: bool, assets: list, no_fetch: bool, github_token: str, use_current_ref: bool, auto_release_notes: bool):
     if publish:
-        if assets is None:
+        # Click provides an empty tuple when no assets are passed. Guard against both
+        # an explicit None (older Click versions / direct invocation) and an empty
+        # collection so we do not accidentally create a release without payload.
+        if not assets:
             raise RuntimeError('--publish requires at least one asset')
 
         if github_token is None:


### PR DESCRIPTION
This patch closes a logic gap in [tools/devops/create-release.py](cci:7://file:///c:/Users/T2430514/Downloads/WSL/tools/devops/create-release.py:0:0-0:0):

* **Problem** – The script’s `--publish` mode was intended to require at least one asset, but Click passes an empty tuple if no assets are provided. The original guard (`if assets is None`) never triggered, allowing empty releases to be drafted.
* **Solution** – Replace the check with `if not assets:` which catches both `None` and empty collections, preventing accidental empty releases.
* **Impact** – Ensures CI and manual runs cannot publish a release without payload, aligning behavior with the CLI contract and avoiding junk tags that require manual cleanup.